### PR TITLE
Fix video visibility calculations - trim values are for FFmpeg seeking, not timeline visibility

### DIFF
--- a/apps/app/src/features/element/elementControl.ts
+++ b/apps/app/src/features/element/elementControl.ts
@@ -1148,21 +1148,13 @@ export class ElementControl extends LitElement {
   appearAllElementInTime() {
     for (let elementId in this.timeline) {
       let filetype = this.timeline[elementId].filetype;
+      // Visibility depends ONLY on timeline position (startTime + duration)
+      // NOT on trim values (which are source file positions for FFmpeg -ss seeking)
       let checkFiletype =
         (this.timeline[elementId].startTime as number) > this.progressTime ||
         (this.timeline[elementId].startTime as number) +
           (this.timeline[elementId].duration as number) <
           this.progressTime;
-
-      if (filetype == "video" || filetype == "audio") {
-        checkFiletype =
-          (this.timeline[elementId].startTime as number) +
-            this.timeline[elementId].trim.startTime >
-            this.progressTime ||
-          this.timeline[elementId].startTime +
-            this.timeline[elementId].trim.endTime <
-            this.progressTime;
-      }
 
       if (checkFiletype) {
         this.hideElement(elementId);

--- a/apps/app/src/features/element/time.ts
+++ b/apps/app/src/features/element/time.ts
@@ -22,22 +22,9 @@ export function isElementVisibleAtTime(
       : element.duration;
   const endTime = startTime + realDuration;
 
-  if (element.filetype === "video") {
-    return isVideoElementVisibleAtTime(timeInMs, element);
-  }
-
+  // Visibility depends ONLY on timeline position (startTime + duration)
+  // NOT on trim values (which are source file positions for FFmpeg -ss seeking)
   return isTimeInRange(timeInMs, startTime, endTime);
-}
-
-export function isVideoElementVisibleAtTime(
-  timeInMs: number,
-  videoElement: VideoElementType,
-) {
-  return isTimeInRange(
-    timeInMs,
-    videoElement.startTime + videoElement.trim.startTime,
-    videoElement.startTime + videoElement.trim.endTime,
-  );
 }
 
 function getAdditionalStartTime(


### PR DESCRIPTION
## Problem

Canvas rendered completely black when opening projects where clips started later on the timeline (e.g., 43-81 seconds). Timeline clips also appeared entirely dark.

## Root Cause

Two functions incorrectly added `trim.startTime/endTime` values to timeline positions for visibility checks:

1. `elementControl.ts` - `appearAllElementInTime()` checked `startTime + trim.startTime > cursor`
2. `time.ts` - `isVideoElementVisibleAtTime()` calculated visibility as `startTime + trim.startTime` to `startTime + trim.endTime`

**The bug:** Trim values are absolute positions in the SOURCE VIDEO file (used by FFmpeg `-ss` parameter for seeking), NOT timeline offsets.

Example:
- Clip at timeline position 43s with `trim.startTime` of 71.3s
- Buggy calculation: `43s + 71.3s = 114.3s`
- Result: Clip marked as "not visible until 114 seconds" ❌
- Reality: Clip should be visible starting at 43 seconds ✅

## The Fix

Changed visibility calculations to use ONLY timeline position:

\`\`\`typescript
// Before (WRONG):
isTimeInRange(
  timeInMs,
  videoElement.startTime + videoElement.trim.startTime,
  videoElement.startTime + videoElement.trim.endTime
);

// After (CORRECT):
isTimeInRange(timeInMs, startTime, endTime);
\`\`\`

Visibility depends ONLY on \`startTime + duration\`, never trim values.

## Files Changed

- \`apps/app/src/features/element/time.ts\` - Removed incorrect video visibility function
- \`apps/app/src/features/element/elementControl.ts\` - Removed buggy video/audio visibility check

## Impact

- ✅ Canvas now renders video content at ALL timeline positions (not just 0s)
- ✅ Clips with large trim values display correctly
- ✅ Timeline clips render correctly (no more dark regions)
- ✅ Mouse interactions work correctly on canvas
- ✅ FFmpeg rendering already used trim values correctly (unchanged)